### PR TITLE
CommandSocket#command

### DIFF
--- a/lib/librevox/command_socket.rb
+++ b/lib/librevox/command_socket.rb
@@ -33,8 +33,7 @@ module Librevox
       end
 
       length = response.headers[:content_length].to_i
-      response.content = @socket.read(length) if length > 0
-
+      response.instance_variable_set(:@content, length > 0 ? @socket.read(length) : "")
       response
     end
 


### PR DESCRIPTION
When i call 
CommandSocket#command :show, :calls
it content is empty

but when i try

CommandSocket#command :show, :tasks
it has content

so, the problem was in Response#content= who do
@content = content.match(/:/) ? headers_2_hash(content) : content
this ok, but when the content, for example include.
  ....sip:1000@.... 

but in CommandSocket is a bug.
