### PR TITLE
Parse body from command reply

### DIFF
--- a/lib/librevox/response.rb
+++ b/lib/librevox/response.rb
@@ -20,7 +20,7 @@ module Librevox
     end
 
     def content= content
-      @content = content.respond_to?(:match) && content.match(/:/) ? headers_2_hash(content) : content
+      @content = content.respond_to?(:match) && content.match(/:/) ? headers_2_hash(content).merge(:body => content.split("\n\n",2)[1].to_s) : content
       @content.each {|k,v| v.chomp! if v.is_a?(String)}
     end
 

--- a/spec/librevox/spec_response.rb
+++ b/spec/librevox/spec_response.rb
@@ -59,4 +59,9 @@ describe Response do
     response = Response.new("Content-Type: api/response", "Foo-Bar: Baz")
     response.command_reply?.should.be.false
   end
+
+  should "parse body from command reply" do
+    response = Response.new("Content-Type: command/reply", "Foo-Bar: Baz\n\nMessage body")
+    response.content[:body].should.equal "Message body"
+  end
 end


### PR DESCRIPTION
Solution picked from Freeswitcher source code. Now not only parses the headers, but also the body, which is available as event.content[:body]
