### PR TITLE
Support inbound event filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ techniques:
 require 'librevox'
 
 class MyInbound < Librevox::Listener::Inbound
+  # Events to listen to (default is ALL")
+  events ['CHANNEL_EXECUTE', 'CUSTOM foo']
+
+  # Filters to apply (optional)
+  filters 'Caller-Context' => ['default']
+
   def on_event e
     puts "Got event: #{e.content[:event_name]}"
   end

--- a/README.md
+++ b/README.md
@@ -39,18 +39,16 @@ techniques:
 require 'librevox'
 
 class MyInbound < Librevox::Listener::Inbound
-  # Events to listen for (default is ALL")
-  event 'CHANNEL_EXECUTE'
-  event 'CUSTOM foo'
+  # Events to listen for (default is ALL)
+  events ['CHANNEL_EXECUTE', 'CUSTOM foo']
 
   # Filters to apply (optional)
-  filter 'Caller-Privacy-Hide-Name', 'no'
-  filter 'Caller-Context', ['default', 'example']
+  filter 'Caller-Context' => ['default', 'example'], 'Caller-Privacy-Hide-Name' => 'no'
 
   def on_event e
     puts "Got event: #{e.content[:event_name]}"
   end
- 
+
   # You can add a hook for a certain event:
   event :channel_hangup do
     # It is instance_eval'ed, so you can use your instance methods etc:
@@ -62,7 +60,7 @@ class MyInbound < Librevox::Listener::Inbound
   event :channel_bridge do |e|
     ...
   end
- 
+
   def do_something
     ...
   end

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ techniques:
 require 'librevox'
 
 class MyInbound < Librevox::Listener::Inbound
-  # Events to listen to (default is ALL")
-  events ['CHANNEL_EXECUTE', 'CUSTOM foo']
+  # Events to listen for (default is ALL")
+  event 'CHANNEL_EXECUTE'
+  event 'CUSTOM foo'
 
   # Filters to apply (optional)
-  filters 'Caller-Context' => ['default']
+  filter 'Caller-Privacy-Hide-Name', 'no'
+  filter 'Caller-Context', ['default', 'example']
 
   def on_event e
     puts "Got event: #{e.content[:event_name]}"

--- a/TODO
+++ b/TODO
@@ -5,8 +5,6 @@
 
 - check command/application input and raise ArgumentError, possibly.
 
-- filter events
-
 - move test suite from bacon -> test/unit.
 
 - test how this works in async mode - I imagine that it might mess with

--- a/lib/librevox/listener/inbound.rb
+++ b/lib/librevox/listener/inbound.rb
@@ -4,23 +4,15 @@ module Librevox
   module Listener
     class Inbound < Base
       class << self
+        attr_reader :subscribe_events
+        attr_reader :subscribe_filters
 
-        def filters
-          @filters ||= {}
+        def events(events)
+          @subscribe_events = events
         end
 
-        def filter(header, values)
-          @filters ||= {}
-          @filters[header] = [*values]
-        end
-
-        def events
-          @events || ['ALL']
-        end
-
-        def event(event)
-          @events ||= []
-          @events << event
+        def filters(filters)
+          @subscribe_filters = filters
         end
       end
 
@@ -39,10 +31,12 @@ module Librevox
 
         send_data "auth #{@auth}\n\n"
 
-        send_data "event plain #{self.class.events.join(' ')}\n\n"
+        events = self.class.subscribe_events || ['ALL']
+        send_data "event plain #{events.join(' ')}\n\n"
 
-        self.class.filters.each do |header, values|
-          values.each do |value|
+        filters = self.class.subscribe_filters || {}
+        filters.each do |header, values|
+          [*values].each do |value|
             send_data "filter #{header} #{value}\n\n"
           end
         end

--- a/lib/librevox/listener/inbound.rb
+++ b/lib/librevox/listener/inbound.rb
@@ -12,11 +12,29 @@ module Librevox
         EventMachine.add_shutdown_hook {@shutdown = true}
       end
 
+      @@filters = {}
+      def self.filters(filters)
+        @@filters = filters
+      end
+
+      @@events = ['ALL']
+      def self.events(events)
+        @@events = [*events]
+      end
+
       def connection_completed
         Librevox.logger.info "Connected."
         super
+
         send_data "auth #{@auth}\n\n"
-        send_data "event plain ALL\n\n"
+
+        send_data "event plain #{@@events.join(' ')}\n\n"
+
+        @@filters.each do |header, filters|
+          [*filters].each do |filter|
+            send_data "filter #{header} #{filter}\n\n"
+          end
+        end
       end
 
       def unbind

--- a/spec/librevox/listener/spec_inbound.rb
+++ b/spec/librevox/listener/spec_inbound.rb
@@ -6,6 +6,12 @@ require 'librevox/listener/inbound'
 class InboundTestListener < Librevox::Listener::Inbound
 end
 
+class InboundFilterTestListener < Librevox::Listener::Inbound
+  events ['CUSTOM', 'CHANNEL_EXECUTE']
+
+  filters 'Caller-Context' => ['default', 'example'], 'Caller-Privacy-Hide-Name' => 'no'
+end
+
 describe "Inbound listener" do
   before do
     @listener = InboundTestListener.new(nil)
@@ -18,5 +24,25 @@ describe "Inbound listener" do
     @listener.connection_completed
     @listener.outgoing_data.shift.should == "auth ClueCon\n\n"
     @listener.outgoing_data.shift.should == "event plain ALL\n\n"
+    @listener.outgoing_data.shift.should == nil
+  end
+end
+
+describe "Inbound listener with filtering" do
+  before do
+    @listener = InboundFilterTestListener.new(nil)
+  end
+
+  behaves_like "events"
+  behaves_like "api commands"
+
+  should "authorize and subscribe to events" do
+    @listener.connection_completed
+    @listener.outgoing_data.shift.should == "auth ClueCon\n\n"
+    @listener.outgoing_data.shift.should == "event plain CUSTOM CHANNEL_EXECUTE\n\n"
+    @listener.outgoing_data.shift.should == "filter Caller-Context default\n\n"
+    @listener.outgoing_data.shift.should == "filter Caller-Context example\n\n"
+    @listener.outgoing_data.shift.should == "filter Caller-Privacy-Hide-Name no\n\n"
+    @listener.outgoing_data.shift.should == nil
   end
 end


### PR DESCRIPTION
Add support for event filters. Based on #9 with the alternative approach suggested there.

Without filtering, Librevox spends a lot of CPU on discarding messages, and FreeSwitch spends a lot of time and CPU on forwarding events that will just be discarded.